### PR TITLE
add Cilium network policy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add `ciliumnetworkpolicy` (disabled by default).
+
 ### Changed
 
 - Configure `gsoci.azurecr.io` as the default container image registry.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Add `ciliumnetworkpolicy` (disabled by default).
+- Add `ciliumnetworkpolicy` (enabled by default).
 
 ### Changed
 

--- a/helm/pss-operator/templates/cilium-network-policy.yaml
+++ b/helm/pss-operator/templates/cilium-network-policy.yaml
@@ -1,0 +1,16 @@
+{{- if .Values.ciliumNetworkPolicy.enabled }}
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: {{ include "resource.default.name"  . }}
+  namespace: {{ include "resource.default.namespace"  . }}
+  labels:
+    {{- include "labels.common" . | nindent 4 }}
+spec:
+  egress:
+  - toEntities:
+    - kube-apiserver
+  endpointSelector:
+    matchLabels:
+      {{- include "labels.selector" . | nindent 6 }}
+{{- end }}

--- a/helm/pss-operator/values.yaml
+++ b/helm/pss-operator/values.yaml
@@ -1,3 +1,6 @@
+ciliumNetworkPolicy:
+  enabled: false
+
 registry:
   domain: gsoci.azurecr.io
 

--- a/helm/pss-operator/values.yaml
+++ b/helm/pss-operator/values.yaml
@@ -1,5 +1,5 @@
 ciliumNetworkPolicy:
-  enabled: false
+  enabled: true
 
 registry:
   domain: gsoci.azurecr.io


### PR DESCRIPTION
this is required for MCs where network policies are enforced on the giantswarm and kube-system namespaces.
